### PR TITLE
Fix subroutine-name typo in error message

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,9 @@
+## Note for archived repository:
+This repository (fork) has been archived and is no longer maintained.
+The code is provided for historical reference and may contain unpatched or unknown vulnerabilities.
+It should not be used in production systems.
+
+
 GD/SVG version 0.24
 ===================
 

--- a/SVG.pm
+++ b/SVG.pm
@@ -1120,7 +1120,7 @@ sub saveAlpha     { shift->_error('saveAlpha'); }
 ##################################################
 # Miscellaneous Image Methods
 ##################################################
-sub interlaced { shift->_error('inerlaced'); }
+sub interlaced { shift->_error('interlaced'); }
 
 sub getBounds {
   my $self = shift;


### PR DESCRIPTION
I initially though the code I was working with called a non-existent subroutine, but it turned out to be a minor typo in the unimplemented-subroutine error message ("inerlaced" -> "interlaced").
